### PR TITLE
COMP: Fix build removing nonexistent resource reference

### DIFF
--- a/LanguageTools/CMakeLists.txt
+++ b/LanguageTools/CMakeLists.txt
@@ -11,7 +11,6 @@ set(MODULE_PYTHON_RESOURCES
   Resources/UI/${MODULE_NAME}.ui
   Resources/Fonts/NotoSansTC-Regular.otf
   Resources/Fonts/NotoSerifTC-Regular.otf
-  Resources/CTK~vtkModalityWidget_LANG.ts
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This removes the reference to `Resources/CTK~vtkModalityWidget_LANG.ts` originally introduced in 2facb49 ("Fix Slicer crash when using localized DICOM module", 2023-04-12) and partially removed in a76855c ("Mark translatable strings", 2024-01-03).

Issue was discovered while testing changes introduced in:
* https://github.com/commontk/CTK/pull/1179