### PR TITLE
Streamline weblate language refresh & remove obsolete Slicer 5.0 workaround

### DIFF
--- a/LanguageTools/LanguageTools.py
+++ b/LanguageTools/LanguageTools.py
@@ -218,17 +218,6 @@ class LanguageToolsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic.logCallback = self.log
     self.textFinder.logic = self.logic
 
-    # Workaround for Slicer-5.0 (no Qt plugin was available for ctkLanguageComboBox)
-    if self.ui.languageSelector.__class__ != ctk.ctkLanguageComboBox:
-      layout = self.ui.languageSelectorLayout
-      layout.removeWidget(self.ui.languageSelector)
-      self.ui.languageSelector.hide()
-      languageSelector = ctk.ctkLanguageComboBox()
-      languageSelector.setSizePolicy(self.ui.languageSelector.sizePolicy)
-      languageSelector.toolTip = self.ui.languageSelector.toolTip
-      layout.addWidget(languageSelector)
-      self.ui.languageSelector = languageSelector
-
     self.ui.languageSelector.countryFlagsVisible = False
     self.ui.languageSelector.defaultLanguage = "en"
     self.ui.languageSelector.directories = slicer.app.translationFolders()

--- a/LanguageTools/LanguageTools.py
+++ b/LanguageTools/LanguageTools.py
@@ -218,8 +218,6 @@ class LanguageToolsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     self.logic.logCallback = self.log
     self.textFinder.logic = self.logic
 
-    self.refreshWeblateLanguageList()
-
     # Workaround for Slicer-5.0 (no Qt plugin was available for ctkLanguageComboBox)
     if self.ui.languageSelector.__class__ != ctk.ctkLanguageComboBox:
       layout = self.ui.languageSelectorLayout


### PR DESCRIPTION
* Streamline Weblate language list refresh: This eliminates the redundant call to `refreshWeblateLanguageList()` within the `setup()` function. The refresh is already triggered by the existing call within `updateGUIFromSettings()` at the end of the `setup()` process.`

* Remove obsolete workaround specific to Slicer 5.0: The ctkLanguageComboBox Qt designer plugin was introduced in 27d9dd79 (`ENH: Improve ctkLanguageComboBox`, 2022-05-04) available in
Slicer >= 5.2. It was integrated in Slicer through Slicer/Slicer@650ed1467a (`BUG: Update to latest CTK version`, 2022-05-17)