### PR TITLE
BUG: Ensure language combobox shows default language

### DIFF
--- a/LanguageTools/LanguageTools.py
+++ b/LanguageTools/LanguageTools.py
@@ -367,7 +367,10 @@ class LanguageToolsWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     self.refreshLanguageList()
     wasBlocked = self.ui.languageSelector.blockSignals(True)
-    self.ui.languageSelector.currentLanguage = settings.value("language")
+    # Ensure older settings with an empty and invalid "language" entry are ignored by
+    # explicitly checking for an empty value.
+    if settings.contains("language") and settings.value("language") != "":
+      self.ui.languageSelector.currentLanguage = settings.value("language")
     self.ui.languageSelector.blockSignals(wasBlocked)
 
     self.logic.customLreleasePath = self.ui.lreleasePathLineEdit.currentPath


### PR DESCRIPTION
This change ensures the fix integrated through commontk/CTK#1179 (BUG: Fix ctkLanguageComboBox normalizing default language and selection) is effective.

After installing the extension without having selected any language:

| Before  | After |
|---|---|
| ![image](https://github.com/Slicer/SlicerLanguagePacks/assets/219043/b3b8fc12-26aa-4bb6-a450-db3d5d93d699) | ![image](https://github.com/Slicer/SlicerLanguagePacks/assets/219043/9599bf2d-fc02-4f2e-9fec-2af2b400bf45) |
